### PR TITLE
Check keys before delete in  _update_expired_keys

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -148,7 +148,7 @@ class _StrKeyDict(MutableMapping):
         for key in deleted:
             if key in self._ex_keys:
                 del self._ex_keys[key]
-            if key in sel:
+            if key in self:
                 del self[key]
 
     def copy(self):

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -146,8 +146,10 @@ class _StrKeyDict(MutableMapping):
                 deleted.append(key)
 
         for key in deleted:
-            del self._ex_keys[key]
-            del self[key]
+            if key in self._ex_keys:
+                del self._ex_keys[key]
+            if key in sel:
+                del self[key]
 
     def copy(self):
         new_copy = _StrKeyDict()


### PR DESCRIPTION
I was running into an issue when use fakeredis and freezegun to manipulate dates in a unit test. The _StrKeyDict._update_expired_keys was trying to delete keys that appeared the _ex_keys dict, but somehow the keys did not appear in the underlying _dict of the class instance.
This just updates the method to verify that the key is contained in the _ex_keys and _dict objects before calling del.
